### PR TITLE
Include scope in the reported item

### DIFF
--- a/example/Example.elm
+++ b/example/Example.elm
@@ -22,6 +22,7 @@ rollbar : Rollbar
 rollbar =
     Rollbar.scoped
         (Rollbar.token token)
+        (Rollbar.codeVersion "0.0.1")
         (Rollbar.environment "test")
         "Example"
 

--- a/example/elm.json
+++ b/example/elm.json
@@ -9,18 +9,20 @@
         "direct": {
             "Skinney/murmur3": "2.0.8",
             "danyx23/elm-uuid": "2.1.2",
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
             "elm/html": "1.0.0",
-            "elm/http": "1.0.0",
-            "elm/json": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0"
         },
         "indirect": {
             "elm/regex": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.2",
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.4"
         }
     },
     "test-dependencies": {

--- a/src/Rollbar.elm
+++ b/src/Rollbar.elm
@@ -197,7 +197,7 @@ sendWithTime vtoken vcodeVersion vscope venvironment maxRetryAttempts level mess
 
         body : Http.Body
         body =
-            toJsonBody vtoken vcodeVersion venvironment level message uuid metadata
+            toJsonBody vtoken vscope vcodeVersion venvironment level message uuid metadata
     in
     { method = "POST"
     , headers = [ tokenHeader vtoken ]
@@ -273,13 +273,14 @@ uuidFrom (Token vtoken) (Scope vscope) (Environment venvironment) level message 
         |> Tuple.first
 
 
-toJsonBody : Token -> CodeVersion -> Environment -> Level -> String -> Uuid -> Dict String Value -> Http.Body
-toJsonBody (Token vtoken) (CodeVersion vcodeVersion) (Environment venvironment) level message uuid metadata =
+toJsonBody : Token -> Scope -> CodeVersion -> Environment -> Level -> String -> Uuid -> Dict String Value -> Http.Body
+toJsonBody (Token vtoken) (Scope vscope) (CodeVersion vcodeVersion) (Environment venvironment) level message uuid metadata =
     -- See https://rollbar.com/docs/api/items_post/ for schema
     [ ( "access_token", Encode.string vtoken )
     , ( "data"
       , Encode.object
             [ ( "environment", Encode.string venvironment )
+            , ( "context", Encode.string vscope )
             , ( "uuid", Uuid.encode uuid )
             , ( "client"
               , Encode.object


### PR DESCRIPTION
Right now it's not possible to determine the source of the http error unless the user supplies that information in the error message. This PR makes it so the "scope" we use to send the item is included in the payload automatically.

![screen shot 2019-03-06 at 18 06 09](https://user-images.githubusercontent.com/753421/53913679-a3173a00-403a-11e9-8e73-4da51b9068e0.png)
